### PR TITLE
Brad/remove unused property

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -70,12 +70,6 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 @property (nonatomic, copy) NSData *passwordData;
 
 /**
- This property automatically transitions between an object and the value of
- `passwordData` using NSKeyedArchiver and NSKeyedUnarchiver.
- */
-@property (nonatomic, copy) id<NSCoding> passwordObject;
-
-/**
  Convenience accessor for setting and getting a password string. Passes through
  to `passwordData` using UTF-8 string encoding.
  */

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -146,19 +146,6 @@
 
 #pragma mark - Accessors
 
-- (void)setPasswordObject:(id<NSCoding>)object {
-	self.passwordData = [NSKeyedArchiver archivedDataWithRootObject:object];
-}
-
-
-- (id<NSCoding>)passwordObject {
-	if ([self.passwordData length]) {
-		return [NSKeyedUnarchiver unarchiveObjectWithData:self.passwordData];
-	}
-	return nil;
-}
-
-
 - (void)setPassword:(NSString *)password {
 	self.passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
 }


### PR DESCRIPTION
This property was causing warnings due to not using NSSecureCoding. Since this property isn't being used anywhere in our project, I just deleted it.