### PR TITLE
SSKeychainQuery: New legacyKeychainMode property

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -14,7 +14,7 @@
 	#define SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE 1
 #endif
 
-#if TARGET_OS_OSX && __MAC_10_15
+#if TARGET_OS_OSX && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_15)
 	// Legacy Keychain Mode is only available in macOS
 	#define SSKEYCHAIN_LEGACY_MODE_AVAILABLE 1
 #endif

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -75,6 +75,11 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
  */
 @property (nonatomic, copy) NSString *password;
 
+/**
+ Indicates whether to treat macOS keychain items like iOS keychain items.
+ */
+@property (nonatomic, assign) BOOL useDataProtectionKeychain;
+
 
 ///------------------------
 /// @name Saving & Deleting

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -80,14 +80,11 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
  */
 @property (nonatomic, copy) NSString *password;
 
-
-#ifdef SSKEYCHAIN_LEGACY_MODE_AVAILABLE
 /**
  When enabled, the Filesystem Based Keychain (Legacy!) will be used.
  By default macOS will query the new DataProtection Keychain
  */
 @property (nonatomic, assign) BOOL legacyKeychainMode;
-#endif
 
 
 ///------------------------

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -158,4 +158,10 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 + (BOOL)isSynchronizationAvailable;
 #endif
 
+
+/**
+ Indicates if the Legacy Keychain Mode is available
+ */
++ (BOOL)isLegacyModeAvailable;
+
 @end

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -14,6 +14,11 @@
 	#define SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE 1
 #endif
 
+#if TARGET_OS_OSX && __MAC_10_15
+	// Legacy Keychain Mode is only available in macOS
+	#define SSKEYCHAIN_LEGACY_MODE_AVAILABLE 1
+#endif
+
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 	SSKeychainQuerySynchronizationModeAny,
@@ -75,10 +80,14 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
  */
 @property (nonatomic, copy) NSString *password;
 
+
+#ifdef SSKEYCHAIN_LEGACY_MODE_AVAILABLE
 /**
- Indicates whether to treat macOS keychain items like iOS keychain items.
+ When enabled, the Filesystem Based Keychain (Legacy!) will be used.
+ By default macOS will query the new DataProtection Keychain
  */
-@property (nonatomic, assign) BOOL useDataProtectionKeychain;
+@property (nonatomic, assign) BOOL legacyKeychainMode;
+#endif
 
 
 ///------------------------

--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -81,10 +81,11 @@ typedef NS_ENUM(NSUInteger, SSKeychainQuerySynchronizationMode) {
 @property (nonatomic, copy) NSString *password;
 
 /**
- When enabled, the Filesystem Based Keychain (Legacy!) will be used.
- By default macOS will query the new DataProtection Keychain
+ When disabled, the Legacy macOS Filesystem-based Keychain will be used.
+ This is useful if you have existing data in the legacy keychain
+ and need to access it on newer systems.
  */
-@property (nonatomic, assign) BOOL legacyKeychainMode;
+@property (nonatomic, assign) BOOL useModernKeychain;
 
 
 ///------------------------

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -46,8 +46,10 @@
 	output.synchronizationMode = self.synchronizationMode;
 #endif
 	
+#ifdef SSKEYCHAIN_LEGACY_MODE_AVAILABLE
 	output.legacyKeychainMode = self.legacyKeychainMode;
-	
+#endif
+
 	return output;
 }
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -194,8 +194,10 @@
 	}
 #endif
 	
-	if (self.useDataProtectionKeychain) {
-		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
+	if (@available(macOS 10.15, *)) {
+		if (self.useDataProtectionKeychain) {
+			[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
+		}
 	}
 
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -194,11 +194,15 @@
 	}
 #endif
 	
+#if (TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE)
+	// NO-OP: Not required in iOS!
+#else
 	if (@available(macOS 10.15, *)) {
 		if (self.useDataProtectionKeychain) {
 			[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
 		}
 	}
+#endif
 
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 	if ([[self class] isSynchronizationAvailable]) {

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -24,6 +24,15 @@
 @synthesize synchronizationMode = _synchronizationMode;
 #endif
 
+- (instancetype)init {
+	self = [super init];
+	if (self) {
+		_useModernKeychain = YES;
+	}
+
+	return self;
+}
+
 #pragma mark - Public
 
 - (BOOL)save:(NSError *__autoreleasing *)error {
@@ -205,10 +214,8 @@
 #endif
 	
 #if SSKEYCHAIN_LEGACY_MODE_AVAILABLE
-	if (@available(macOS 10.15, *)) {
-		if (self.legacyKeychainMode == NO) {
-			[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
-		}
+	if (self.useModernKeychain) {
+		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
 	}
 #endif
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -193,6 +193,10 @@
 		[dictionary setObject:self.accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
 	}
 #endif
+	
+	if (self.useDataProtectionKeychain) {
+		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain]
+	}
 
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 	if ([[self class] isSynchronizationAvailable]) {

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -26,31 +26,6 @@
 
 #pragma mark - Public
 
-- (id)copyWithZone:(NSZone *)zone
-{
-	SSKeychainQuery *output = [self.class new];
-	output.account = self.account;
-	output.service = self.service;
-	output.label = self.label;
-	output.comment = self.comment;
-	
-#ifdef SSKEYCHAIN_ACCESSIBLE_AVAILABLE
-	output.accessibilityType = self.accessibilityType;
-#endif
-
-#if SSKEYCHAIN_ACCESSGROUP_AVAILABLE
-	output.accessGroup = self.accessGroup;
-#endif
-	
-#ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
-	output.synchronizationMode = self.synchronizationMode;
-#endif
-	
-	output.legacyKeychainMode = self.legacyKeychainMode;
-
-	return output;
-}
-
 - (BOOL)save:(NSError *__autoreleasing *)error {
 	OSStatus status = SSKeychainErrorBadArguments;
 	if (!self.service || !self.account || !self.passwordData) {

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -194,13 +194,9 @@
 	}
 #endif
 	
-#if (TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE)
-	// NO-OP: Not required in iOS!
-#else
-	if (@available(macOS 10.15, *)) {
-		if (self.useDataProtectionKeychain) {
-			[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
-		}
+#if SSKEYCHAIN_LEGACY_MODE_AVAILABLE
+	if (self.legacyKeychainMode == NO) {
+		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
 	}
 #endif
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -200,6 +200,14 @@
 }
 #endif
 
++ (BOOL)isLegacyModeAvailable {
+#if SSKEYCHAIN_LEGACY_MODE_AVAILABLE
+	return YES;
+#else
+	return NO;
+#endif
+}
+
 
 #pragma mark - Private
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -46,9 +46,7 @@
 	output.synchronizationMode = self.synchronizationMode;
 #endif
 	
-#ifdef SSKEYCHAIN_LEGACY_MODE_AVAILABLE
 	output.legacyKeychainMode = self.legacyKeychainMode;
-#endif
 
 	return output;
 }
@@ -202,10 +200,12 @@
 
 + (BOOL)isLegacyModeAvailable {
 #if SSKEYCHAIN_LEGACY_MODE_AVAILABLE
-	return YES;
-#else
-	return NO;
+	if (@available(macOS 10.15, *)) {
+		return YES;
+	}
 #endif
+
+	return NO;
 }
 
 
@@ -230,8 +230,10 @@
 #endif
 	
 #if SSKEYCHAIN_LEGACY_MODE_AVAILABLE
-	if (self.legacyKeychainMode == NO) {
-		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
+	if (@available(macOS 10.15, *)) {
+		if (self.legacyKeychainMode == NO) {
+			[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
+		}
 	}
 #endif
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -195,7 +195,7 @@
 #endif
 	
 	if (self.useDataProtectionKeychain) {
-		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain]
+		[dictionary setObject:@(YES) forKey:(__bridge id)kSecUseDataProtectionKeychain];
 	}
 
 #ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -26,6 +26,31 @@
 
 #pragma mark - Public
 
+- (id)copyWithZone:(NSZone *)zone
+{
+	SSKeychainQuery *output = [self.class new];
+	output.account = self.account;
+	output.service = self.service;
+	output.label = self.label;
+	output.comment = self.comment;
+	
+#ifdef SSKEYCHAIN_ACCESSIBLE_AVAILABLE
+	output.accessibilityType = self.accessibilityType;
+#endif
+
+#if SSKEYCHAIN_ACCESSGROUP_AVAILABLE
+	output.accessGroup = self.accessGroup;
+#endif
+	
+#ifdef SSKEYCHAIN_SYNCHRONIZATION_AVAILABLE
+	output.synchronizationMode = self.synchronizationMode;
+#endif
+	
+	output.legacyKeychainMode = self.legacyKeychainMode;
+	
+	return output;
+}
+
 - (BOOL)save:(NSError *__autoreleasing *)error {
 	OSStatus status = SSKeychainErrorBadArguments;
 	if (!self.service || !self.account || !self.passwordData) {


### PR DESCRIPTION
### Details:
- By default, `SSKeychainQuery` will now use the "Data macOS Keychain"
- A new property was added (`legacyMode`), which allows us to query the "Legacy" internal implementation

Required by this [DayOne macOS PR](https://github.com/bloom/DayOne-iOS/pull/18629), and [this issue](https://github.com/bloom/DayOne-iOS/issues/18193).

[Apple forums ref. here!](https://developer.apple.com/forums/thread/697317)